### PR TITLE
[WIP] Register SW using API Prototype.

### DIFF
--- a/admin/pages/theme-settings.php
+++ b/admin/pages/theme-settings.php
@@ -355,10 +355,9 @@
 				<h2 class="title">Add to Home Screen</h2>
 				<div class="spacer-20"></div>
 				<p>In order for your users to be prompted to add the app to their home screen you must add a service worker to the root of your domain.</p>
+				<!-- Removed since the content of the SW file is dynamically served via SW API prototype. <div class="spacer-10"></div><p>Move the 'sw.js' file which is located in the 'wordpress-mobile-pack' plugin directory to the root of your domain '/' using FTP.</p>-->
 				<div class="spacer-10"></div>
-				<p>Move the 'sw.js' file which is located in the 'wordpress-mobile-pack' plugin directory to the root of your domain '/' using FTP.</p>
-				<div class="spacer-10"></div>
-				<p>Once you have moved the file to your root, check the box bellow and click 'save'. For more details visit the <a href="https://docs.wpmobilepack.com/wp-mobile-pack-free/look-and-feel.html" target="_blank">support page.</a></p>
+				<p>Check the box bellow and click 'save'. For more details visit the <a href="https://docs.wpmobilepack.com/wp-mobile-pack-free/look-and-feel.html" target="_blank">support page.</a></p>
 				<div class="spacer-30"></div>
 				<form name="wmp_service_worker_form" id="wmp_service_worker_form" class="left" action="<?php echo admin_url('admin-ajax.php'); ?>?action=wmp_settings_save" method="post" style="min-width: 300px;">
 					<?php $installed = WMobilePack_Options::get_setting('service_worker_installed'); ?>

--- a/frontend/themes/app2/template.php
+++ b/frontend/themes/app2/template.php
@@ -66,13 +66,6 @@ if ($texts_json_exists === false) {
 		};
 	</script>
 	<script src="<?php echo $theme_path;?>js/app.js?date=20170503" type="text/javascript"></script>
-	<?php if ($app_settings['service_worker_installed'] == 1): ?>
-		<script>
-			if ('serviceWorker' in navigator) {
-				navigator.serviceWorker.register('/sw.js');
-			}
-		</script>
-	<?php endif; ?>
     <?php
         // check if google analytics id was set
         if ($app_settings['google_analytics_id'] != ''):

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,7 @@
-self.addEventListener('fetch', function(event) {
-	
-	event.respondWith(fetch(event.request));
-	
-});
+( function() {
+	self.addEventListener('fetch', function(event) {
+
+		event.respondWith(fetch(event.request));
+
+	});
+} );

--- a/wordpress-mobile-pack.php
+++ b/wordpress-mobile-pack.php
@@ -29,6 +29,15 @@ function wmobilepack_admin_init() {
     new WMobilePack_Admin_Init();
 }
 
+/**
+ * Register service worker.
+ */
+function wpmobilepack_register_service_worker() {
+	if ( function_exists( 'wp_register_service_worker' ) ) {
+		wp_register_service_worker( 'wpmobilepack-service-worker', plugin_dir_url( __FILE__ ) . 'sw.js' );
+	}
+}
+
 if (class_exists( 'WMobilePack' ) && class_exists( 'WMobilePack' )) {
 
     global $wmobile_pack;
@@ -68,5 +77,7 @@ if (class_exists( 'WMobilePack' ) && class_exists( 'WMobilePack' )) {
     } else {
         add_action('plugins_loaded', 'wmobilepack_frontend_init');
     }
+
+    add_action( 'plugins_loaded', 'wpmobilepack_register_service_worker' );
 
 }


### PR DESCRIPTION
Basic service worker registration using the [SW API Prototype](https://github.com/xwp/pwa-wp/pull/14).

Removes information for the user to move `sw.js` and instead registers the file within the plugin's root directory.

Relevant output of `https://src.wordpress-develop.test/?wp_service_worker=/`:
![screen shot 2018-07-05 at 1 10 06 pm](https://user-images.githubusercontent.com/3294597/42317372-e467a482-8054-11e8-8c91-93fe8e1704bc.png)

